### PR TITLE
feat: Add placeholder text to calculator inputs (#5)

### DIFF
--- a/mercalculator.kv
+++ b/mercalculator.kv
@@ -16,6 +16,7 @@
 
         TextInput:
             id: numor1
+            hint_text: "Numerator 1"
             input_type: "number"
             multiline: False
             halign: "center"
@@ -24,6 +25,7 @@
 
         TextInput:
             id: numor2
+            hint_text: "Numerator 2"
             input_type: "number"
             multiline: False
             halign: "center"
@@ -32,6 +34,7 @@
 
         TextInput:
             id: denor1
+            hint_text: "Denominator 1"
             input_type: "number"
             multiline: False
             halign: "center"


### PR DESCRIPTION
Adds the `hint_text` property to the `TextInput` widgets for the numerators and the denominator.

Closes #5 